### PR TITLE
When working with exception XML, use error code not error name

### DIFF
--- a/src/assertions.xqy
+++ b/src/assertions.xqy
@@ -78,23 +78,23 @@ declare function assert:not-empty(
 
 declare function assert:error(
   $actual as item()*,
-  $expected-error-name as xs:string
+  $expected-error-code as xs:string
 ) as element(xray:assert)
 {
-  assert:error($actual, $expected-error-name, ())
+  assert:error($actual, $expected-error-code, ())
 };
 
 declare function assert:error(
   $actual as item()*,
-  $expected-error-name as xs:string,
+  $expected-error-code as xs:string,
   $message as xs:string?
 ) as element(xray:assert)
 {
-  let $actual-error-name :=
-    if ($actual instance of element(error:error)) then $actual/error:name/fn:string()
+  let $actual-error-code :=
+    if ($actual instance of element(error:error)) then $actual/error:code/fn:string()
     else ()
-  let $status := $actual-error-name = $expected-error-name
-  return xray:test-response("error", $status, ($actual-error-name, $actual)[1], $expected-error-name, $message)
+  let $status := $actual-error-code = $expected-error-code
+  return xray:test-response("error", $status, ($actual-error-code, $actual)[1], $expected-error-code, $message)
 };
 
 

--- a/src/utils.xqy
+++ b/src/utils.xqy
@@ -80,7 +80,7 @@ declare private function parse-xquery(
   return
     let $parsed := xqp:parse($source)
     return
-      if ($parsed/self::ERROR) then fn:error(xs:QName("XRAY-PARSE"), "Error parsing module", $parsed)
+      if ($parsed/self::ERROR) then fn:error((), "XRAY-PARSE", ("Error parsing module", $parsed))
       else if ($TEST-NS-URI eq $parsed/Module/LibraryModule/ModuleDecl/URILiteral/@value)
       then $parsed
       else ()

--- a/test/subfolder/test-ignore.xqy
+++ b/test/subfolder/test-ignore.xqy
@@ -5,5 +5,5 @@ import module namespace assert = "http://github.com/robwhitby/xray/assertions" a
 
 declare function should-not-include-modules-not-in-xray-test-namespace()
 {
-  fn:error((), "this test should not be invoked")
+  fn:error((), 'XRAY-IGNORE', "this test should not be invoked")
 };

--- a/test/tests.xqy
+++ b/test/tests.xqy
@@ -8,7 +8,7 @@ declare namespace xray = "http://github.com/robwhitby/xray";
 
 
 
-(: 
+(:
   optional setup function evaluated first
   add any test docs used by the tests in this module
 :)
@@ -114,7 +114,7 @@ declare function
   assert:not-empty(fn:doc("doc1.xml"))
 };
 
-declare function 
+declare function
 test:check-doc1-is-searchable()
 {
   let $results := cts:search(fn:collection("test"), "foo")
@@ -123,18 +123,18 @@ test:check-doc1-is-searchable()
 
 declare private function test:should-not-run-private-function()
 {
-  fn:error((), "this test is private!")
+  fn:error((), 'XRAY-PRIVATE', "this test is private!")
 };
 
 declare function IGNORE-should-skip-this-test()
 {
-  fn:error((), "this test should be ignored!")
+  fn:error((), 'XRAY-PRIVATE', "this test should be ignored!")
 };
 
 (:
-declare function test:should-not-attempt-to-run-commented-out-function() 
+declare function test:should-not-attempt-to-run-commented-out-function()
 {
-  fn:error((), "this test is commented out!")
+  fn:error((), 'XRAY-PRIVATE', "this test is commented out!")
 };
 :)
 
@@ -166,7 +166,7 @@ declare function should-be-able-to-test-simple-cts-query-equality()
 
 declare function should-be-able-to-test-complex-cts-query-equality()
 {
-  let $query := 
+  let $query :=
     cts:or-query((
       cts:element-value-query(xs:QName("foo"), ("bar", "baz"), ("unstemmed", "case-insensitive"), 5),
       cts:word-query("foo", "stemmed", 10)
@@ -187,10 +187,10 @@ declare function should-include-optional-assert-message-on-failure()
 
 declare function IGNORE-should-also-skip-this-test()
 {
-  fn:error((), "this test should be ignored!")
+  fn:error((), 'XRAY-IGNORE', "this test should be ignored!")
 };
 
-declare function should-be-able-to-import-module-using-relative-path() 
+declare function should-be-able-to-import-module-using-relative-path()
 {
   let $foo := utils:upper("foo")
   return assert:equal($foo, "FOO")


### PR DESCRIPTION
There's room for some argument here, but I think the emphasis on the `error:name` element is at odds with the way the server itself uses the error schema. Take a look at the exception thrown by a built-in function:

```
try { cts:search('', ()) } catch ($ex) { $ex }

<error:error xsi:schemaLocation="http://marklogic.com/xdmp/error error.xsd" xmlns:error="http://marklogic.com/xdmp/error" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <error:code>XDMP-UNSEARCHABLE</error:code>
  <error:name/>
  <error:xquery-version>1.0-ml</error:xquery-version>
  <error:message>Expression is unsearchable</error:message>
  <error:format-string>XDMP-UNSEARCHABLE: cts:search("", cts:and-query((), ())) -- Expression is unsearchable</error:format-string>
```

...

The `XDMP-UNSEARCHABLE` bit is the code, not the name. The way to generate this with `fn:error` is to leave arg1 empty, put the code in arg2, and put anything else into arg3. The error handling in cq and qconsole uses a similar convention.
