### PR TITLE
include xml declaration when returning xunit xml

### DIFF
--- a/src/output/xunit.xsl
+++ b/src/output/xunit.xsl
@@ -5,7 +5,7 @@
 				version="2.0"
 				exclude-result-prefixes="xray xdmp error">
 
-	<xsl:output method="xml" omit-xml-declaration="yes" indent="yes"/>
+	<xsl:output method="xml" omit-xml-declaration="no" indent="yes"/>
 
 	<xsl:param name="test-dir"/>
 	<xsl:param name="module-pattern"/>


### PR DESCRIPTION
Unless there is a reason not to? Some tools seem to expect this.
