### PR TITLE
Code coverage feature from Michael Blakeley

### DIFF
--- a/coverage.xqy
+++ b/coverage.xqy
@@ -1,0 +1,27 @@
+xquery version "1.0-ml";
+(:
+ : Display coverage for a library module.
+ :)
+
+import module namespace cover="http://github.com/robwhitby/xray/coverage"
+  at "src/coverage.xqy";
+import module namespace xray="http://github.com/robwhitby/xray"
+  at "src/xray.xqy";
+
+(: library module path :)
+declare variable $module as xs:string := xdmp:get-request-field("module");
+
+(: output format html|text|xml :)
+declare variable $format as xs:string := xdmp:get-request-field("format", "html");
+
+(: wanted lines :)
+declare variable $wanted as xs:integer* := xs:integer(
+  xs:NMTOKENS(xdmp:get-request-field("wanted")));
+
+(: covered lines :)
+declare variable $covered as xs:integer* := xs:integer(
+  xs:NMTOKENS(xdmp:get-request-field("covered")));
+
+cover:module-view($module, $format, $wanted, $covered)
+
+(: coverage :)

--- a/index.xqy
+++ b/index.xqy
@@ -11,8 +11,14 @@ declare variable $modules as xs:string? := xdmp:get-request-field("modules");
 (: test name matcher regex :)
 declare variable $tests as xs:string? := xdmp:get-request-field("tests");
 
-(: output format xml|html|text :)
+(: output format html|text|xml|xunit :)
 declare variable $format as xs:string := xdmp:get-request-field("format", "html");
 
+(: library module paths for code coverage :)
+declare variable $coverage-modules as xs:string* := distinct-values(
+  if ($format = 'xunit') then ()
+  else xdmp:get-request-field("coverage-module"));
 
-xray:run-tests($dir, $modules, $tests, $format)
+xray:run-tests($dir, $modules, $tests, $format, $coverage-modules)
+
+(: index.xqy :)

--- a/src/coverage.xqy
+++ b/src/coverage.xqy
@@ -1,0 +1,465 @@
+xquery version "1.0-ml";
+
+(: coverage.xqy
+ :
+ : Library functions for code coverage.
+ :
+ : @author Michael Blakeley
+ :)
+
+module namespace cover = "http://github.com/robwhitby/xray/coverage";
+
+import module namespace utils = "http://github.com/robwhitby/xray/utils"
+  at "utils.xqy";
+
+declare default element namespace "http://github.com/robwhitby/xray";
+
+declare variable $NBSP := fn:codepoints-to-string(160);
+
+declare private function cover:_sequence-from-map(
+  $map as map:map)
+{
+  for $k in map:keys($map)
+  order by $k
+  return xs:integer($k)
+};
+
+declare private function cover:_put(
+  $map as map:map,
+  $key as xs:string)
+{
+  map:put($map, $key, $key)
+};
+
+declare private function cover:_put-new(
+  $map as map:map,
+  $key as xs:string)
+{
+  if (fn:exists(map:get($map, $key))) then ()
+  else cover:_put($map, $key)
+};
+
+declare private function cover:_map-from-sequence(
+  $map as map:map,
+  $seq as xs:integer*)
+{
+  cover:_put($map, xs:string($seq)),
+  $map
+};
+
+declare private function cover:_map-from-sequence(
+  $seq as xs:integer*)
+{
+  cover:_map-from-sequence(map:map(), $seq)
+};
+
+(:
+ : This function stops on breakpoints, updating the results map.
+ : This is dead code, but might come in handy some time.
+ :)
+declare private function cover:actual-via-debug(
+  $request as xs:unsignedLong,
+  $modules as xs:string+,
+  $results-map as map:map)
+{
+  (: Advance to the first breakpoint. :)
+  dbg:finish($request),
+  (: Conserve stack space by using a loop instead of recursion. :)
+  try {
+    let $timeout := 125
+    for $i in 1 to 7654321
+    let $status := dbg:status($request)
+    let $expr-id := $status/dbg:request/dbg:expr-id/fn:data(.)
+    (: If there is no expression and the request is not running, we are done. :)
+    let $is-running := ($status/dbg:request/dbg:request-status = 'running')
+    let $should-wait := fn:not($expr-id) and $is-running
+    let $is-break := fn:not($expr-id) and fn:not($is-running)
+    let $maybe-detach :=
+      if (fn:not($is-break) or fn:empty($status/dbg:request)) then ()
+      else
+        try { dbg:detach($request) }
+        catch ($ex) {
+          if (fn:not($ex/error:code = 'DBG-REQUESTRECORD')) then xdmp:rethrow()
+          else () }
+    return
+      if ($is-break) then fn:error((), 'XRAY-BREAKLOOP')
+      else if ($should-wait) then dbg:wait($request, $timeout)
+      else
+        let $expr as element() := dbg:expr($request, $expr-id)
+        let $uri := ($expr/dbg:uri/fn:string(), '')[1]
+        let $map := map:get($results-map, $uri)[1]
+        let $key := $expr/dbg:line/fn:string()
+        (: In theory we should never put the same key twice. :)
+        let $put := cover:_put($map, $key)
+        let $clear := dbg:clear($request, $expr-id)
+        let $continue := dbg:continue($request)
+        return dbg:wait($request, $timeout) }
+  catch ($ex) {
+    if (fn:not($ex/error:code = 'XRAY-BREAKLOOP')) then xdmp:rethrow()
+    else () }
+};
+
+declare function cover:cover(
+  $request as xs:unsignedLong,
+  $modules as xs:string+,
+  $results-map as map:map)
+{
+  cover:actual-via-debug($request, $modules, $results-map)
+  ,
+  for $uri in $modules
+  let $map := map:get($results-map, $uri)[1]
+  return xdmp:log(
+    text { 'DEBUG', $uri, 'actual', map:count($map), 'lines' })
+  ,
+  (: reprocess :)
+  for $key in map:keys($results-map)
+  let $seq := map:get($results-map, $key)
+  let $actual := $seq[1]
+  let $wanted := $seq[2]
+  let $assert :=
+    if (map:count($actual - $wanted) eq 0) then ()
+    else fn:error((), 'BAD', map:keys($actual - $wanted))
+  order by $key
+  return element coverage {
+    attribute uri { $key },
+    element wanted {
+      for $line in xs:integer(map:keys($wanted))
+      order by $line
+      return $line },
+    element actual {
+      for $line in xs:integer(map:keys($actual))
+      order by $line
+      return $line },
+    element missing {
+      for $line in xs:integer(map:keys($wanted - $actual))
+      order by $line
+      return $line } }
+};
+
+declare private function cover:_prepare-from-request(
+  $request as xs:unsignedLong,
+  $uri as xs:string,
+  $results-map as map:map)
+{
+  xdmp:log(text { 'DEBUG request', $request, 'module', $uri }),
+  try {
+    let $lines-map := map:get($results-map, $uri)[2]
+    (: Semi-infinite loop, to be broken using DBG-LINE.
+     : This avoids stack overflow errors.
+     : Half a million lines of XQuery ought to be enough for any module.
+     :)
+    for $line in 1 to 654321
+    (: We only need to break once per line, but we set a breakpoint
+     : on every expression to maximize the odds of seeing that line.
+     : But dbg:line will return the same expression more than once,
+     : at the start of a module or when it sees an expression
+     : that covers multiple lines. So we call dbg:expr for the right info.
+     : Faster to loop once and call dbg:expr many extra times,
+     : or gather all unique expr-ids and then loop again?
+     : Because of the loop-break technique, one loop is easier.
+     :)
+    for $expr-id in dbg:line($request, $uri, $line)
+    let $set := dbg:break($request, $expr-id)
+    let $expr := dbg:expr($request, $expr-id)
+    let $key := $expr/dbg:line/fn:string()
+    where fn:not(map:get($lines-map, $key))
+    return cover:_put($lines-map, $key) }
+  catch ($ex) {
+    if (fn:not($ex/error:code = 'DBG-LINE')) then xdmp:rethrow()
+    else () }
+};
+
+declare private function cover:_prepare-R(
+  $fn as xdmp:function,
+  $rest as xdmp:function*,
+  $results-map as map:map)
+{
+  (: TODO implement caching :)
+  xdmp:log(text { 'DEBUG function', $fn, fn:count($rest) }),
+  let $modules := map:keys($results-map)
+  let $request := dbg:eval(utils:query($fn))
+  let $do := (
+    _prepare-from-request($request, $modules, $results-map),
+    xdmp:request-cancel(
+      xdmp:host(), dbg:value($request, 'xdmp:server()'), $request))
+  let $modules-remaining :=
+    for $uri in $modules
+    where map:count(map:get($results-map, $uri)[2]) eq 0
+    return $uri
+  (: Continue recursion until we run out of modules or functions.
+   : If we run out of functions, the results will show 0 lines to be covered.
+   :)
+  return
+    if (fn:not($modules-remaining)) then ()
+    else if (fn:not($rest)) then ()
+    else cover:_prepare-R($rest[1], fn:subsequence($rest, 2), $results-map)
+};
+
+(:~
+ : This function prepares code coverage information for the specified modules.
+ :)
+declare private function cover:_prepare(
+  $modules as xs:string+,
+  $functions as xdmp:function*,
+  $results-map as map:map)
+as map:map
+{
+  (: When this comes back, each map key will have two entries:
+   : covered-lines-map, wanted-lines-map.
+   : The wanted-lines-map will be an identity map.
+   :)
+  for $m in $modules
+  return map:put($results-map, $m, (map:map(), map:map()))
+  ,
+  cover:_prepare-R(
+    $functions[1], fn:subsequence($functions, 2), $results-map)
+  ,
+  $results-map
+  (: TODO remove debugging code :)
+  ,
+  for $uri in $modules
+  let $map := map:get($results-map, $uri)[2]
+  return xdmp:log(
+    text { 'DEBUG', $uri, 'wants', map:count($map), 'lines' })
+};
+
+(:~
+ : This function prepares code coverage information for the specified modules.
+ :)
+declare function cover:prepare(
+  $modules as xs:string*,
+  $functions as xdmp:function*)
+as map:map?
+{
+  if (fn:not($modules)) then ()
+  else cover:_prepare($modules, $functions, map:map())
+};
+
+declare private function cover:_result(
+  $name as xs:string,
+  $map as map:map)
+{
+  element { $name } {
+    attribute count { map:count($map) },
+    for $line in xs:integer(map:keys($map))
+    order by $line
+    return $line }
+};
+
+declare function cover:results(
+  $results-map as map:map,
+  $results as item()*,
+  $did-succeed as xs:boolean)
+{
+  (: TODO if we bring in cprof this will need to change. :)
+  $results[fn:not(. instance of element(prof:report))]
+  ,
+  if (fn:not($did-succeed)) then () else
+  (: report test-level coverage data :)
+  let $modules := map:keys($results-map)
+  let $do := (
+    (: Populate the coverage maps from the profiler output. :)
+    for $expr in $results[
+      . instance of element(prof:report)]/prof:histogram/prof:expression[
+      prof:uri = $modules ]
+    let $m := map:get($results-map, $expr/prof:uri)[1]
+    let $key := $expr/prof:line/fn:string()
+    where fn:not(map:get($m, $key))
+    return cover:_put($m, $key))
+  for $uri in $modules
+  let $seq := map:get($results-map, $uri)
+  let $covered := $seq[1]
+  let $wanted := $seq[2]
+  let $assert :=
+    if (map:count($covered - $wanted) eq 0) then ()
+    else fn:error((), 'BAD', map:keys($covered - $wanted))
+  order by $uri
+  return element coverage {
+    attribute uri { $uri },
+    cover:_result('wanted', $wanted),
+    cover:_result('covered', $covered),
+    cover:_result('missing', $wanted - $covered)
+  }
+};
+
+declare function cover:transform(
+  $tests as element()
+)
+{
+  element { fn:node-name($tests) } {
+    $tests/@*
+    ,
+    let $map := map:map()
+    let $do := (
+      for $c in $tests/module/test/coverage
+      let $uri := $c/@uri/fn:string()
+      let $old := map:get($map, $uri)
+      let $old := (
+        (: Do we already have a 'wanted' list for this uri? :)
+        if (fn:exists($old)) then $old else (
+          let $new := (map:map(), map:map())
+          let $put := map:put($map, $uri, $new)
+          return $new))
+      let $covered := $old[1]
+      let $wanted := $old[2]
+      let $do := (
+        cover:_put-new($covered, xs:NMTOKENS($c/covered)),
+        if (map:count($wanted) or 0 eq $c/wanted/@count) then ()
+        else cover:_put-new($wanted, xs:NMTOKENS($c/wanted)))
+      return ())
+    let $seq := map:get($map, '*')
+    let $covered-count := fn:sum(
+      for $uri in map:keys($map)
+      return map:count(map:get($map, $uri)[1]))
+    let $wanted-count := fn:sum(
+      for $uri in map:keys($map)
+      return map:count(map:get($map, $uri)[2]))
+    return element coverage-summary {
+      attribute wanted-count { $wanted-count },
+      attribute covered-count { $covered-count },
+      attribute missing-count { $wanted-count - $covered-count },
+      (: by module :)
+      for $uri in map:keys($map)
+      let $seq := map:get($map, $uri)
+      let $covered := $seq[1]
+      let $wanted := $seq[2]
+      order by $uri
+      return element module-coverage {
+        attribute uri { $uri },
+        cover:_result('wanted', $wanted),
+        cover:_result('covered', $covered),
+        cover:_result('missing', $wanted - $covered) } }
+    ,
+    $tests/node() }
+};
+
+declare function cover:module-view-html(
+  $module as xs:string,
+  $lines as xs:string*,
+  $wanted as map:map,
+  $covered as map:map,
+  $missing as map:map)
+{
+  xdmp:set-response-content-type('text/xml'),
+  <html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+      <title>Coverage for { $module }</title>
+      <link rel="icon" type="image/png" href="favicon.ico" />
+      <link rel="stylesheet" type="text/css" href="xray.css" />
+    </head>
+    <body>
+      <h1>
+        <a href="http://robwhitby.github.com/xray">xray</a>
+      </h1>
+      <div class="module">
+        <h3>Code Coverage for { $module }</h3>
+        <div class="source">
+  {
+    for $i at $x in $lines
+    let $key := fn:string($x)
+    let $class :=
+      if (map:get($covered, $key)) then 'covered-line'
+      else if (map:get($wanted, $key)) then 'wanted-line'
+      else 'line'
+    return element div {
+      attribute class { $class },
+      element span {
+        attribute class { 'lineno' },
+        $x },
+      if ($i) then $i else $NBSP }
+  }
+        </div>
+      </div>
+    </body>
+  </html>
+};
+
+declare function cover:module-view-text(
+  $module as xs:string,
+  $lines as xs:string*,
+  $wanted as map:map,
+  $covered as map:map,
+  $missing as map:map)
+{
+  xdmp:set-response-content-type('text/plain'),
+  text { 'Module', $module },
+  for $i at $x in $lines
+  let $key := fn:string($x)
+  return text {
+    if (map:get($covered, $key)) then '+'
+    else if (map:get($wanted, $key)) then '!'
+    else ' ',
+    $x, $i }
+};
+
+declare function cover:module-view-xml(
+  $module as xs:string,
+  $lines as xs:string*,
+  $wanted as map:map,
+  $covered as map:map,
+  $missing as map:map)
+{
+  xdmp:set-response-content-type('text/xml'),
+  <module xmlns="http://github.com/robwhitby/xray">
+  {
+    attribute uri { $module },
+    for $i at $x in $lines
+    let $key := fn:string($x)
+    return element line {
+      attribute number { $x },
+      attribute state {
+        if (map:get($covered, $key)) then 'covered'
+        else if (map:get($wanted, $key)) then 'wanted'
+        else 'none'},
+      $i }
+  }
+  </module>
+};
+
+declare function cover:module-view(
+  $module as xs:string,
+  $format as xs:string,
+  $lines as xs:string*,
+  $wanted as map:map,
+  $covered as map:map,
+  $missing as map:map)
+{
+  if ($format eq 'html') then cover:module-view-html(
+    $module, $lines, $wanted, $covered, $missing)
+  else if ($format eq 'text') then cover:module-view-text(
+    $module, $lines, $wanted, $covered, $missing)
+  else if ($format eq 'xml') then cover:module-view-xml(
+    $module, $lines, $wanted, $covered, $missing)
+  else fn:error(
+    (), 'XRAY-BADFORMAT',
+    ('Format invalid for code coverage view:', $format))
+};
+
+declare function cover:module-view(
+  $module as xs:string,
+  $format as xs:string,
+  $lines as xs:string*,
+  $wanted as map:map,
+  $covered as map:map
+)
+{
+  cover:module-view(
+    $module, $format, $lines,
+    $wanted, $covered, $wanted - $covered)
+};
+
+declare function cover:module-view(
+  $module as xs:string,
+  $format as xs:string,
+  $wanted as xs:integer*,
+  $covered as xs:integer*)
+{
+  cover:module-view(
+    $module, $format,
+    fn:tokenize(utils:get-module($module, fn:false()), '\n'),
+    cover:_map-from-sequence($wanted),
+    cover:_map-from-sequence($covered))
+};
+
+
+(: src/coverage.xqy :)

--- a/src/modules-database.xqy
+++ b/src/modules-database.xqy
@@ -2,11 +2,33 @@ xquery version "1.0-ml";
 
 module namespace modules-db = "http://github.com/robwhitby/xray/modules-db";
 
+declare variable $ROOT := xdmp:modules-root();
+
 declare private variable $eval-options :=
   <options xmlns="xdmp:eval">
     <database>{xdmp:modules-database()}</database>
   </options>;
-	
+
+
+declare private function append-path(
+  $path as xs:string,
+  $step as xs:string
+) as xs:string
+{
+  fn:concat(
+    $path, if (fn:ends-with($path, '/')) then '' else '/',
+    if (fn:starts-with($step, '/')) then fn:substring-after($step, '/')
+    else $step)
+};
+
+
+declare function resolve-path(
+  $path as xs:string
+) as xs:string
+{
+  append-path($ROOT, $path)
+};
+
 
 declare function get-modules(
   $test-dir as xs:string,
@@ -27,11 +49,11 @@ declare function get-modules(
       and fn:matches($uri, "\.xqy?$")
       and fn:matches(fn:substring-after($uri, $modules-root), fn:string($pattern))
     return $uri
-  ', 
+  ',
   (
-    xs:QName("test-dir"), $test-dir, 
+    xs:QName("test-dir"), $test-dir,
     xs:QName("pattern"), $pattern,
-    xs:QName("modules-root"), xdmp:modules-root()
+    xs:QName("modules-root"), $ROOT
   ),
   $eval-options)
 };
@@ -39,13 +61,13 @@ declare function get-modules(
 
 declare function get-module(
   $module-path as xs:string
-) as xs:string 
+) as xs:string
 {
   xdmp:eval('
     xquery version "1.0-ml";
     declare variable $uri as xs:string external;
     fn:doc($uri)
-  ', 
+  ',
   (xs:QName("uri"), $module-path),
   $eval-options)
 };

--- a/src/output/text.xsl
+++ b/src/output/text.xsl
@@ -1,5 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		            xmlns:xray="http://github.com/robwhitby/xray"
+                xmlns:xray="http://github.com/robwhitby/xray"
                 xmlns:error="http://marklogic.com/xdmp/error"
                 version="2.0">
 
@@ -11,7 +11,28 @@
     <xsl:value-of select="', Failed', count(xray:module/xray:test[@result='failed'])" />
     <xsl:value-of select="', Ignored', count(xray:module/xray:test[@result='ignored'])" />
     <xsl:value-of select="', Errors', count(xray:module/error:error)" />
-    <xsl:value-of select="', Passed', count(xray:module/xray:test[@result='passed'])" /> 
+    <xsl:value-of select="', Passed', count(xray:module/xray:test[@result='passed'])" />
+  </xsl:template>
+
+  <xsl:template match="xray:coverage-summary">
+    <xsl:variable name="covered" select="@covered-count"/>
+    <xsl:variable name="wanted" select="@wanted-count"/>
+    <xsl:text>Code Coverage: </xsl:text>
+    <xsl:value-of
+        select="concat(round(100 * $covered div $wanted), '%')"/>
+    <xsl:text>&#10;</xsl:text>
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="xray:module-coverage">
+    <xsl:variable name="covered" select="xray:covered/@count"/>
+    <xsl:variable name="wanted" select="xray:wanted/@count"/>
+    <xsl:text>-- </xsl:text>
+    <xsl:value-of select="@uri"/>
+    <xsl:text> -- </xsl:text>
+    <xsl:value-of
+        select="concat(round(100 * $covered div $wanted), '%')"/>
+    <xsl:text>&#10;</xsl:text>
   </xsl:template>
 
   <xsl:template match="xray:module">

--- a/xray.css
+++ b/xray.css
@@ -1,0 +1,57 @@
+/* xray.css */
+
+body { margin: 0 10px; }
+body, input, button { font-family: "Courier New",Sans-serif; }
+h1 { margin: 0 0 30px 0; }
+h1 a:link, h1 a:visited, h1 a:hover, h1 a:active {
+    padding: 10px 10px;
+    text-decoration:none; color: #fff;
+    background-color: #000;
+    border: 1px solid #000;
+    text-shadow: #fff 1px 1px 15px;
+    -webkit-font-smoothing: antialiased;
+}
+h1 a:hover { color: #000; background-color: #fff; }
+h3, h4, pre { margin: 0; padding: 5px 10px; font-weight: normal; }
+h3 { background-color: #eee; }
+label { padding-left: 10px; }
+abbr, .abbr { border-bottom: 1px dotted #ccc; }
+form { position: absolute; top: 10px; right: 10px; }
+#summary { font-weight: bold; }
+.module { border: 1px solid #ccc; margin: 10px 0; }
+.failed { color: red; }
+.ignored { color: orange; }
+.passed { color: green; }
+.code .s { color: red; }
+.code .v { color: purple; }
+.code .f { color: blue; }
+.code .x { color: green; }
+
+.coverage-summary {
+    border: 1px solid #ccc;
+    margin: 10px 0;
+}
+
+li.module-coverage {
+    list-style-type: none;
+}
+
+.source
+{
+    font-family: monospace, -moz-fixed !important;
+    white-space: pre;
+}
+
+.lineno
+{
+    background-color: #eee;
+    margin-left: 0;
+    margin-right: 0.25em;
+    float: left;
+    width: 3em;
+}
+
+.covered-line { background-color: green; }
+.wanted-line { background-color: red; }
+
+/* xray.css */


### PR DESCRIPTION
This work was done for Zynx Health, so we are checking the change in on our
fork.  Apologies for having checked this into master.

Here is a description of the feature from the man himself:

There's no UI for specifying the coverage-module arguments yet. To run
xray's own unit tests with code coverage enabled, use a URL like this one:

```
http://localhost:8889/xray/?dir=xray/test&modules=&tests=&coverage-module=/xray/src/assertions.xqy&coverage-module=/xray/src/utils.xqy&format=html
```

Any number of 'coverage-module' URIs can be specified. If there are no
coverage-modules specified, no code coverage will be run. Once you have
the html report, you can click on the links in the code coverage summary
to display the details for a module. That display also supports xml and
text formats.

It turned out that I could support unit testing and code coverage in the
same run, too. Code coverage is disabled for format=xunit, because xunit
doesn't seem to have schema support for code coverage. But format=xml
shows the full line info, and text shows summary information without
links.
