### PR TITLE
Absolute paths throw off app-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Tests are grouped into library modules in the xray test namespace. Import the xr
 ```xquery
 xquery version "1.0-ml";
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 import module namespace some-module = "http://some-module-to-test" at "/some-module-to-test.xqy";
 

--- a/src/xray.xqy
+++ b/src/xray.xqy
@@ -125,7 +125,7 @@ declare function run-module(
   try {
     xdmp:eval('
       xquery version "1.0-ml";
-      import module namespace xray = "http://github.com/robwhitby/xray" at "/xray/src/xray.xqy";
+      import module namespace xray = "http://github.com/robwhitby/xray" at "/src/xray.xqy";
       import module namespace test = "http://github.com/robwhitby/xray/test" at "' || $path || '";
       declare variable $xray:path as xs:string external;
       declare variable $xray:test-pattern as xs:string external;

--- a/test/default-fn-namespace.xqy
+++ b/test/default-fn-namespace.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 declare default function namespace "http://www.w3.org/2005/xpath-functions";
 

--- a/test/error-handling.xqy
+++ b/test/error-handling.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 
 declare private function something-that-errors() {

--- a/test/module-import-root-relative.xqy
+++ b/test/module-import-root-relative.xqy
@@ -1,9 +1,9 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
-import module namespace utils = "utils" at "/xray/test/utils.xqy";
+import module namespace utils = "utils" at "/test/utils.xqy";
 
 
 declare %test:case function should-be-able-to-import-module-using-root-relative-path()

--- a/test/more-tests/module-import-relative.xqy
+++ b/test/more-tests/module-import-relative.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 import module namespace utils = "utils" at "../utils.xqy";
 

--- a/test/setup-teardown-multiple.xqy
+++ b/test/setup-teardown-multiple.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 
 (:

--- a/test/setup-teardown.xqy
+++ b/test/setup-teardown.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 
 (:

--- a/test/skip-non-xray-modules.xqy
+++ b/test/skip-non-xray-modules.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "some other namespace";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 
 declare %test:case function should-not-include-modules-not-in-xray-test-namespace()

--- a/test/syntax-error.xqy
+++ b/test/syntax-error.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 
 declare %test:case function syntax-error-in-module()

--- a/test/tests.xqy
+++ b/test/tests.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 declare namespace xray = "http://github.com/robwhitby/xray";
 import module namespace utils = "utils" at "utils.xqy";

--- a/test/updates.xqy
+++ b/test/updates.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 
 declare %test:case function assert-timestamp()

--- a/test/xquery3.xqy
+++ b/test/xquery3.xqy
@@ -1,7 +1,7 @@
 xquery version "1.0-ml";
 
 module namespace test = "http://github.com/robwhitby/xray/test";
-import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
+import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/src/assertions.xqy";
 
 
 declare %test:case function simple-mapping-operator()


### PR DESCRIPTION
xray app server should point to the xray folder and let index.xqy handle the rewrite.

Scenario: already have an app running in /opt/{nameofapp}/ml with app server pointed there
Put xray next to it at /opt/{nameofapp}/xray, create an app-server that points to /opt/{nameofapp}/xray

The test files and src/xray.xqy use absolute paths /xray/.....
Since the appserver is already pointed here, it looks for /opt/{nameofapp}/xray/xray/....

Absolute paths are evil, the refs should assume the app server is already pointed to the location of the directory that contains index.xqy and look for subfolders from where they currently reside.
