### PR TITLE
Forcing order of tests

### DIFF
--- a/src/xray.xqy
+++ b/src/xray.xqy
@@ -148,9 +148,12 @@ declare function run-module-tests(
   $test-pattern as xs:string
 ) as element()*
 {
-  let $fns := xdmp:functions()[
+  let $fns := for $f in xdmp:functions()[
     has-test-annotation(., ("case", "ignore", "setup", "teardown")) and fn:matches(fn-local-name(.), $test-pattern)
   ]
+  order by local-name-from-QName(function-name($f))
+  return $f
+  
   return (
     apply($fns[has-test-annotation(., "setup")], $path),
     run-test($fns[has-test-annotation(., "case") or has-test-annotation(., "ignore")], $path),


### PR DESCRIPTION
In our case, we need to pass the tests in a predetermined order (especially when testing insert & delete of documents), so i'm just forcing the order of the functions by their name.
