### PR TITLE
Alternate time calculation

### DIFF
--- a/src/xray.xqy
+++ b/src/xray.xqy
@@ -55,7 +55,6 @@ declare function run-test(
   $path as xs:string
 ) as element(test)
 {
-  let $start-time as xs:dayTimeDuration := xdmp:elapsed-time()
   let $ignore := has-test-annotation($fn, "ignore")
   let $map := if ($ignore) then () else xray:apply($fn, $path)
   let $test := map:get($map, "results")
@@ -68,7 +67,7 @@ declare function run-test(
       else if ($test//descendant-or-self::assert[@result="failed"]) then "failed"
       else "passed"
     },
-    attribute time { $time (:xdmp:elapsed-time() - $start-time:) },
+    attribute time { $time },
     $test
   }
 };
@@ -166,9 +165,9 @@ declare function run-module-tests(
     order by $name
     return $f
   return (
-    apply($fns[has-test-annotation(., "setup")], $path),
+    map:get(apply($fns[has-test-annotation(., "setup")], $path), "results"),
     run-test($fns[has-test-annotation(., "case") or has-test-annotation(., "ignore")], $path),
-    apply($fns[has-test-annotation(., "teardown")], $path)
+    map:get(apply($fns[has-test-annotation(., "teardown")], $path), "results")
   )
 };
 


### PR DESCRIPTION
This puts the duration calculation inside the xdmp:eval().  When tests take a matter of milliseconds to run the "overhead" of the eval function seems to outweigh the actual timings of the test itself.  I was thinking some of my operations were taking over 200 ms (not bad, unless you are trying to handle thousands of those per second) only to find the "real" time of my ops were only around 10 ms (much better for scale).

Am I missing something?  Does this approach cause other problems?
