### PR TITLE
Also allow *.xqm library modules

### DIFF
--- a/src/modules-database.xqy
+++ b/src/modules-database.xqy
@@ -6,7 +6,7 @@ declare private variable $eval-options :=
   <options xmlns="xdmp:eval">
     <database>{xdmp:modules-database()}</database>
   </options>;
-	
+
 
 declare function get-modules(
   $test-dir as xs:string,
@@ -24,12 +24,12 @@ declare function get-modules(
     let $uri := xdmp:node-uri($doc)
     where
       fn:starts-with($uri, $uri-prefix)
-      and fn:matches($uri, "\.xqy?$")
+      and fn:matches($uri, "\.xq[my]?$")
       and (fn:ends-with($uri, $pattern) or fn:matches(fn:substring-after($uri, $modules-root), fn:string($pattern)))
     return $uri
-  ', 
+  ',
   (
-    xs:QName("test-dir"), $test-dir, 
+    xs:QName("test-dir"), $test-dir,
     xs:QName("pattern"), $pattern,
     xs:QName("modules-root"), xdmp:modules-root()
   ),

--- a/src/modules-filesystem.xqy
+++ b/src/modules-filesystem.xqy
@@ -14,7 +14,7 @@ declare function get-modules(
     else fn:replace($test-dir, "\\", "/")
   let $fs-dir := fn:concat(xdmp:modules-root(), fn:replace($test-dir, "^[/\\]+", ""))
   where filesystem-directory-exists($fs-dir)
-  return 
+  return
     module-filenames($fs-dir)[fn:ends-with(., $pattern) or fn:matches(fn:substring-after(., $fs-dir), fn:string($pattern))]
 };
 
@@ -28,7 +28,7 @@ declare private function module-filenames(
   return
     if ($entry/dir:type = "file")
     then
-      if (fn:matches($entry/dir:pathname, "\.xqy?$"))
+      if (fn:matches($entry/dir:pathname, "\.xq[my]?$"))
       then $entry/dir:pathname/fn:string()
       else ()
     else module-filenames($entry/dir:pathname/fn:string())
@@ -40,10 +40,10 @@ declare private function filesystem-directory-exists(
 ) as xs:boolean
 {
   try  { fn:exists(xdmp:filesystem-directory($dir)) }
-  catch($e) 
-  { 
-    if ($e/error:code = "SVC-DIROPEN") 
-    then fn:false() 
+  catch($e)
+  {
+    if ($e/error:code = "SVC-DIROPEN")
+    then fn:false()
     else xdmp:rethrow()
   }
 };


### PR DESCRIPTION
Some projects use `xqm` as the suffix for library modules. It would be nice if xray supported this convention.

Looks like my editor also did some whitespace cleanup: sorry for that extra noise.
