### PR TITLE
#38 pass ipv4 option to curl.

### DIFF
--- a/test-runner.sh
+++ b/test-runner.sh
@@ -51,7 +51,7 @@ do
 done
 
 URL="$BASEURL?format=$FORMAT&modules=$MODULES&tests=$TESTS&dir=$DIR"
-CURL="curl --silent"
+CURL="curl --silent --ipv4"
 if [ -n "$CREDENTIAL" ]; then
     CURL="$CURL --anyauth --user $CREDENTIAL"
 fi


### PR DESCRIPTION
This should be safe for existing releases of MarkLogic, which only support ipv4 anyway.