### PR TITLE
Use XQuery 3 syntax for private methods and try/catch

### DIFF
--- a/src/assertions.xqy
+++ b/src/assertions.xqy
@@ -132,7 +132,7 @@ declare function assert:false(
 };
 
 
-declare private function deep-equal(
+declare %private function deep-equal(
   $a as item()*,
   $b as item()*
 ) as xs:boolean

--- a/src/modules-database.xqy
+++ b/src/modules-database.xqy
@@ -2,7 +2,7 @@ xquery version "1.0-ml";
 
 module namespace modules-db = "http://github.com/robwhitby/xray/modules-db";
 
-declare private variable $eval-options :=
+declare %private variable $eval-options :=
   <options xmlns="xdmp:eval">
     <database>{xdmp:modules-database()}</database>
   </options>;

--- a/src/modules-filesystem.xqy
+++ b/src/modules-filesystem.xqy
@@ -16,7 +16,7 @@ declare function get-modules(
 };
 
 
-declare private function module-filenames(
+declare %private function module-filenames(
   $dir as xs:string
 ) as xs:string*
 {
@@ -32,14 +32,14 @@ declare private function module-filenames(
 };
 
 
-declare private function filesystem-directory-exists(
+declare %private function filesystem-directory-exists(
   $dir as xs:string
 ) as xs:boolean
 {
   try  { fn:exists(xdmp:filesystem-directory($dir)) }
-  catch($e)
+  catch *
   {
-    if ($e/error:code = "SVC-DIROPEN")
+    if ($err:code = "SVC-DIROPEN")
     then fn:false()
     else xdmp:rethrow()
   }

--- a/src/modules.xqy
+++ b/src/modules.xqy
@@ -7,8 +7,8 @@ declare namespace test = "http://github.com/robwhitby/xray/test";
 import module namespace modules-fs = "http://github.com/robwhitby/xray/modules-fs" at "modules-filesystem.xqy";
 import module namespace modules-db = "http://github.com/robwhitby/xray/modules-db" at "modules-database.xqy";
 
-declare private variable $TEST-NS-URI := fn:namespace-uri-for-prefix("test", <test:x/>);
-declare private variable $USE-MODULES-DB := (xdmp:modules-database() ne 0);
+declare %private variable $TEST-NS-URI := fn:namespace-uri-for-prefix("test", <test:x/>);
+declare %private variable $USE-MODULES-DB := (xdmp:modules-database() ne 0);
 
 
 declare function get-modules(

--- a/src/xray.xqy
+++ b/src/xray.xqy
@@ -92,7 +92,7 @@ declare function assert-response(
 };
 
 
-declare private function apply(
+declare %private function apply(
   $fn as function(*),
   $path as xs:string
 ) as item()*
@@ -145,17 +145,17 @@ declare function run-module(
     (xs:QName("path"), $path, xs:QName("test-pattern"), fn:string($test-pattern))
     )
   }
-  catch($ex) {
+  catch * {
     (: https://github.com/spig/xray/commit/3bf0e7facaa5260f19556bf431469d967d00c3c1 :)
-    switch ($ex/error:code)
+    switch ($err:code)
       case "XDMP-IMPMODNS"
         return
-          if ($ex/error:data/error:datum/fn:contains(., $path)) then
+          if ($err:additional/error:datum/fn:contains(., $path)) then
             () (: ignore - module not in test namespace :)
           else $ex (: must be an error in an import of the $path module :)
       case "XDMP-IMPORTMOD"
         return
-          if ($ex/error:data/error:datum/fn:contains(., $path)) then
+          if ($err:additional/error:datum/fn:contains(., $path)) then
             () (: ignore - main module if path of current module :)
           else $ex (: must be an error in an import of the $path module :)
       default return $ex
@@ -192,7 +192,7 @@ declare function has-test-annotation(
 };
 
 
-declare private function fn-local-name(
+declare %private function fn-local-name(
   $fn as function(*)
 ) as xs:string
 {
@@ -200,7 +200,7 @@ declare private function fn-local-name(
 };
 
 
-declare private function transform(
+declare %private function transform(
   $el as element(),
   $test-dir as xs:string,
   $module-pattern as xs:string?,

--- a/test/error-handling.xqy
+++ b/test/error-handling.xqy
@@ -4,16 +4,16 @@ module namespace test = "http://github.com/robwhitby/xray/test";
 import module namespace assert = "http://github.com/robwhitby/xray/assertions" at "/xray/src/assertions.xqy";
 
 
-declare private function something-that-errors() {
+declare %private function something-that-errors() {
   fn:error((), "MY-ERROR", "something went wrong")
 };
 
 declare %test:case function should-be-able-to-assert-error-code()
 {
-  let $actual := try { something-that-errors() } catch ($ex) { $ex }
+  let $actual := try { something-that-errors() } catch * { $err:description }
   return (
     assert:error($actual, "MY-ERROR"),
-    assert:equal($actual/error:data/fn:string(), "something went wrong")
+    assert:equal($actual, "something went wrong")
   )
 };
 

--- a/test/setup-teardown-multiple.xqy
+++ b/test/setup-teardown-multiple.xqy
@@ -9,7 +9,7 @@ import module namespace assert = "http://github.com/robwhitby/xray/assertions" a
   add any test docs used by the tests in this module
 :)
 
-declare private variable $test-docs :=
+declare %private variable $test-docs :=
   <docs>
     <doc uri="one.xml">
       <root><test>one</test></root>

--- a/test/setup-teardown.xqy
+++ b/test/setup-teardown.xqy
@@ -9,7 +9,7 @@ import module namespace assert = "http://github.com/robwhitby/xray/assertions" a
   add any test docs used by the tests in this module
 :)
 
-declare private variable $test-docs :=
+declare %private variable $test-docs :=
   <docs>
     <doc uri="one.xml">
       <root><test>one</test></root>

--- a/test/tests.xqy
+++ b/test/tests.xqy
@@ -77,7 +77,7 @@ declare %test:case function should-be-able-to-test-empty-xpath()
   return assert:empty($xml/p[3])
 };
 
-declare private function get-xml()
+declare %private function get-xml()
 {
   <test><p>para 1</p><p>para 2</p></test>
 };


### PR DESCRIPTION
My motivation for this is to be able to parse the XRay code base using an XQuery parser generated by the REx parser generator. I am looking to examine and generate some stats about XQuery projects and XRay is one of the projects I am looking at.

These changes should all be compatible with `1.0-ml`. I am not certain how MarkLogic populates the `$err:` variables in a catch statement, so my assumptions where I have changed try/catch may need a quick check... 