### PR TITLE
Add xray.gradle and skeleton build.gradle to run XRay tests from a Gradle build, tweak README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ declare %test:case function string-equality-example ()
 
 ## Getting Started
 * Clone/copy/symlink xray into the root directory of your project e.g.<br/>
-`git clone git://github.com/robwhitby/xray.git`  
-or  
-`git submodule add git://github.com/robwhitby/xray.git` 
+`git clone git://github.com/robwhitby/xray.git`  <br/>
+or<br/>
+`git submodule add git://github.com/robwhitby/xray.git` <br/>
+or<br/>
+`git subtree add --prefix path/to/xray/parent git://github.com/robwhitby/xray.git master --squash`
+` 
 * Create an HTTP app server pointing to the root directory of your project.
 * Check all is well at `http://server:port/xray/`
 * Write some tests..
@@ -102,6 +105,10 @@ This still allows using `-t` and `-m` to select which tests to run but removes t
 
 See `run-xray-tests.sh` for an example.
 
+## Running XRay tests from Gradle
+
+If you build your project with Gradle, you can run XRay tests along with the `test` task by
+including the `xray.gradle` file in your build.gradle (see instruction in that file).
 
 ## Assertions
 ```xquery

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,29 @@
+
+/*
+	This is a skeleton build.gradle file that shows how to utilize the xray.gradle test runner
+	extension for Gradle.  This is NOT the build.gradle for the XRay project itself.
+	Ron Hitchens (ron@overstory.co.uk)
+ */
+
+buildscript {
+	repositories {
+		jcenter()
+		mavenCentral()
+	}
+	dependencies {
+		classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'	// Needed for XRay
+	}
+}
+
+apply from: 'xray.gradle'
+apply plugin: 'java'
+
+// If not using the 'java' plugin, comment out this line and just run "gradle xray"
+test.dependsOn (xray)
+
+// ------------------------------
+
+task wrapper(type: Wrapper) {
+    gradleVersion = '4.3.1'
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'	// Needed for XRay
+		classpath 'io.github.http-builder-ng:http-builder-ng-core:1.0.+'	// Not needed here, but satisfies dependencies for IDE editing of xray.gradle
 	}
 }
 

--- a/xray.gradle
+++ b/xray.gradle
@@ -1,11 +1,11 @@
-
 /*
 	Gradle file to run XRay tests.  Including this in your gradle project will enable running of
 	XRay tests along with the 'test' task in your build.  If any XRay tests fail/error, then the
 	build will fail.
 
 	To use this, the XRay XQuery unit testing framework must be installed and invokable on an
-	HTTP appserver.  See the XRay project for details:
+	HTTP appserver.  The default is http://localhost:1234/xray (see properties below)  See the
+	XRay project for details:
 
 		https://github.com/robwhitby/xray
 
@@ -13,16 +13,11 @@
 
 		apply from: 'xray.gradle'
 
-	And add the http-builder dependency to the buildscript/dependencies section there (it needs
-	to be in scope before this script starts)
-
-		classpath group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
-
 	In your build.gradle file, just add this line to run XRay tests with defaults:
 
 		test.dependsOn (xray)
 
-	Note that the above requires that you apply either the Java or Groovy plugin to define the compile/test/build
+	Note that the above requires that you also apply either the Java or Groovy plugin to define the compile/test/build
 	lifecycle tasks.  If you don't want/need those, you can run the xray task directly.
 
 	This will run the XRay tests with defaults, or the property settings found in scope.  To customize
@@ -35,13 +30,15 @@
 		xray.path=/xray
 		xray.user=
 		xray.password=
+		xray.quiet=true
+		xray.basic-auth=false
+		xray.outputXUnit=true
 
-	These are the defaults (user and password are empty by default).  If user/password are supplied, then HTTP basic
-	credentials are applied to the request.  Digest auth is currently not possible, because the HttpBuilder class does
-	not support it.
+	These are the defaults (user and password are empty by default).  If user/password are supplied, then HTTP digest
+	credentials are applied to the request (or basic credentials if basic-auth is true).
 
-	If you want to specify settings in your build.gradle then configure the task like this (settable properties are at the
-	top of the XRayTask class below)
+	If you want to specify settings directly in your build.gradle then configure the task like this (settable properties are
+	at the top of the XRayTask class below)
 
 		xray {
 			host = 'dev.mycompany.com'
@@ -61,10 +58,9 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+		classpath 'io.github.http-builder-ng:http-builder-ng-core:1.0.+'
 	}
 }
-
 
 task xray (type: XRayTask) {
 	group = 'verification'
@@ -73,23 +69,27 @@ task xray (type: XRayTask) {
 
 // -------------------------------------------------------------------------
 
-import groovyx.net.http.HTTPBuilder
-import groovyx.net.http.Method
-import groovyx.net.http.HttpResponseDecorator
 import groovy.util.slurpersupport.GPathResult
+import groovy.xml.StreamingMarkupBuilder
+import groovy.xml.XmlUtil
+import groovyx.net.http.FromServer
+import groovyx.net.http.HttpBuilder
 
 class XRayTask extends DefaultTask
 {
 	public String scheme = getPropertyWithDefault ('xray.scheme', 'http')
 	public String host = getPropertyWithDefault ('xray.hostname', 'localhost')
-	public int port = Integer.parseInt (getPropertyWithDefault ('xray.port', '1234'))
-	public String path = getPropertyWithDefault ('xray.path', '/xray')	// the path to invoke xray/index.xqy on the appserver
+	public int port = Integer.parseInt (getPropertyWithDefault('xray.port', '1234'))
+	public String path = getPropertyWithDefault ('xray.path', '/xray')// the path to invoke xray/index.xqy on the appserver
 	public String user = getPropertyWithDefault ('xray.user', null)
 	public String password = getPropertyWithDefault ('xray.password', null)
-	public boolean quiet = Boolean.parseBoolean (getPropertyWithDefault ('xray.quiet', 'false'))	// set true to suppress passing tests
-	public Map<String,String> parameters = [:]	// XRay query params for dir, module, etc.  Not settable by properties.  Format is always forced to 'xml'.
+	public boolean basicAuth = Boolean.parseBoolean (getPropertyWithDefault ('xray.basic-auth', 'false'))
+	public boolean quiet = Boolean.parseBoolean (getPropertyWithDefault ('xray.quiet', 'false'))// set true to suppress passing tests
+	public Map<String, String> parameters = [:]	// XRay query params for dir, module, etc.  Not settable by properties.  Format is always forced to 'xml'.
+	public boolean outputXUnit = Boolean.parseBoolean (getPropertyWithDefault ('xray.output-xunit', 'true'))	// set false to suppress JUnit-style output
 
-	private static final Map<String,String> colors = [failed:'\033[31m', error: '\033[1;31m', passed: '\033[32m', ignored: '\033[33m']
+	static String markLogicErrorNS = 'http://marklogic.com/xdmp/error'
+	private static final Map<String, String> colors = [failed: '\033[31m', error: '\033[1;31m', passed: '\033[32m', ignored: '\033[33m']
 
 	@TaskAction
 	void runXRay()
@@ -100,56 +100,54 @@ class XRayTask extends DefaultTask
 
 			printResults (results, quiet, colors, startTime)
 		} catch (TaskExecutionException e) {
-			throw e		// pass through, thrown from printResults if there were failures
+			throw e        // pass through, thrown from printResults if there were failures
 		} catch (Exception e) {
 			println "XRay: Unexpected exception invoking XRay tests: ${e}"
-			throw new TaskExecutionException (this, e)
+			throw new TaskExecutionException(this, e)
 		}
 	}
 
 	private GPathResult invokeXrayTests()
 	{
 		String uriString = "${scheme}://${host}:${port}${path}"
-		HTTPBuilder builder = new HTTPBuilder (uriString)
-		String result = null
-
-		if (user != null) builder.auth.basic (user, password)
 
 		println "XRay tests starting on ${uriString}"
 
-		builder.request (Method.GET) {
-			parameters ['format'] = 'xml'
-			uri.query = parameters
+		HttpBuilder http = HttpBuilder.configure {
+			request.uri = uriString
 
-			response.success = { HttpResponseDecorator resp ->
-				if (resp.statusLine.statusCode == 200) {
-					result = resp.entity.content.text
+			if (user != null) {
+				if (basicAuth) {
+					request.auth.basic (user, password)
 				} else {
-					String msg = "HTTP request unexpected HTTP response: ${resp.statusLine.statusCode}"
-					println msg
-					throw new RuntimeException (msg)
+					request.auth.digest (user, password)
 				}
-
-			}
-			response.failure = { HttpResponseDecorator resp ->
-				String msg = "Unexpected error response from XRay tests: ${resp.statusLine.statusCode}"
-				println msg
-				throw new RuntimeException (msg)
 			}
 		}
 
-		new XmlSlurper().parseText (result)
+		return http.get {
+			parameters['format'] = 'xml'
+			request.uri.query = parameters
+
+			response.success { FromServer fs, Object body ->
+				body
+			}
+
+			response.failure { FromServer fs ->
+				String msg = "Unexpected error response from XRay tests: ${fs.statusCode}"
+				println msg
+				throw new RuntimeException (msg)
+			}
+		} as GPathResult
 	}
 
-	private void printResults (GPathResult xml, boolean quiet, Map<String,String> colors, long startTime)
+	private void printResults (GPathResult xml, boolean quiet, Map<String, String> colors, long startTime)
 	{
 		int pass = 0
 		int ignore = 0
 		int fail = 0
 		int error = 0
 		int total = 0
-
-		Set<String> notPass = ["failed", "error"]
 
 		xml.module.each {
 			total += Integer.parseInt (it.'@total'.text())
@@ -161,41 +159,102 @@ class XRayTask extends DefaultTask
 			int e = Integer.parseInt (it.'@error'.text())
 			error += e
 
-			boolean printModuleInfo = ( ! quiet) || ((e + f + i) != 0)
+			boolean printModuleInfo = (!quiet) || ((e + f + i) != 0)
 
-			if (printModuleInfo)  {
+			if (printModuleInfo) {
 				println "Module: ${it.'@path'.text()}, total=${it.'@total'.text()}, pass=${it.'@passed'.text()}, fail=${it.'@failed'.text()}, error=${it.'@error'.text()}, ignore=${it.'@ignored'.text()}"
 			}
 
 			it.test.each {
+				it.declareNamespace (error: markLogicErrorNS)
+
 				String result = it.'@result'.text()
-				boolean printTestDetail = ( ! quiet) || ( ! "passed".equals (result))
+				boolean printTestDetail = (!quiet) || (!"passed".equals(result))
 
-				if (printTestDetail) println " ${colors[result]}${result.toUpperCase()}\033[0m: ${it.'@name'.text()} (${it.'@time'.text()})"
+				if (printTestDetail) println " ${colors[result]}${result.toUpperCase()}: ${it.'@name'.text()}\033[0m (${it.'@time'.text()})"
 
-				if (notPass.contains (result)) {
+				if ('failed'.equals (result)) {
 					println "     assert: ${it.assert.'@test'.text()}"
 					println "     actual: ${it.assert.actual.text()}"
 					println "   expected: ${it.assert.expected.text()}"
 					println "    message: ${it.assert.message.text()}"
 				}
+
+				if ('error'.equals (result)) {
+					if (it.'error:error'.'error:message') {
+						println "  Message: ${it.'error:error'.'error:message'.text()}, see xUnit output for stack trace"
+					} else {
+						println "  Unknown error, see xUnit output for details"
+					}
+				}
 			}
+
+			if (outputXUnit) this.writeXUnit (it)
 		}
 
-		double seconds = (double)(System.currentTimeMillis() - startTime) / 1000.0
+		double seconds = (double) (System.currentTimeMillis() - startTime) / 1000.0
 		int notPassed = error + fail
-		String color = (notPassed != 0) ? colors ['failed'] : (ignore != 0) ? colors ['ignored'] : colors ['passed']
+		String color = (notPassed != 0) ? colors['failed'] : (ignore != 0) ? colors['ignored'] : colors['passed']
 
 		println "XRay results: ${color}total=${total}, pass=${pass}, fail=${fail}, error=${error}, ignore=${ignore}\033[0m, elapsed ${seconds} seconds"
 
 		if (notPassed > 0) {
-			throw new TaskExecutionException (this, new RuntimeException ("There were ${notPassed} XRay test failures"))
+			throw new TaskExecutionException (this, new RuntimeException ("There ${(notPassed == 1) ? 'was' : 'were'} ${notPassed} XRay test failure${(notPassed == 1) ? '' : 's'}"))
 		}
+	}
+
+	private final String testFilePathRoot = "${project.buildDir.path}/test-results/test"
+	private final File  testsDir = new File (testFilePathRoot)
+
+	void writeXUnit (GPathResult m)
+	{
+		if ( ! testsDir.exists()) {
+			if ( ! testsDir.mkdirs()) {
+				throw new TaskExecutionException (this, new RuntimeException ("Cannot create xUnit test output directory: ${testsDir.path}"))
+			}
+		}
+
+		StreamingMarkupBuilder builder = new StreamingMarkupBuilder()
+		builder.encoding = 'UTF-8'
+
+		def xml = builder.bind {
+			mkp.declareNamespace (error: markLogicErrorNS)
+
+			it.testsuite (name: m.'@path'.text(), classname: m.'@path'.text(), tests: m.'@total'.text(), errors: m.'@error'.text(), failures: m.'@failed'.text(), skipped: m.'@ignored'.text()) {
+				m.test.each { GPathResult t ->
+					t.declareNamespace (error: markLogicErrorNS)
+
+					it.testcase (name: t.'@name'.text(), time: t.'@time'.text()) {
+						switch (t.'@result'.text()) {
+						case 'passed':
+							break
+						case 'ignored':
+							skipped()
+							break
+						case 'error':
+							error (message: t.'error:error'.'error:message'.text()) {
+								mkp.yieldUnescaped (builder.bindNode (t.'*').toString())
+							}
+							break
+						case 'failed':
+							failure (type: t.assert.'@test'.text(), "expected: ${t.assert.expected.text()}, actual: ${t.assert.actual.text()}, message: ${t.assert.message.text()}".toString())
+							break
+						}
+					}
+				}
+			}
+		}
+
+		String testFilename = "${testFilePathRoot}/TEST-${m.'@path'.text().substring (1).replaceAll ('/|\\\\', '_')}.xml"
+		FileOutputStream stream = new FileOutputStream (new File (testFilename))
+
+		stream << XmlUtil.serialize (xml)
+
+		stream.close()
 	}
 
 	private String getPropertyWithDefault (String propName, String defaultValue)
 	{
-		(project.hasProperty (propName)) ? project.properties[propName] : defaultValue
+		(project.hasProperty(propName)) ? project.properties[propName] : defaultValue
 	}
 }
-

--- a/xray.gradle
+++ b/xray.gradle
@@ -80,7 +80,7 @@ class XRayTask extends DefaultTask
 	public String scheme = getPropertyWithDefault ('xray.scheme', 'http')
 	public String host = getPropertyWithDefault ('xray.hostname', 'localhost')
 	public int port = Integer.parseInt (getPropertyWithDefault('xray.port', '1234'))
-	public String path = getPropertyWithDefault ('xray.path', '/xray')// the path to invoke xray/index.xqy on the appserver
+	public String path = getPropertyWithDefault ('xray.path', '/xray/')	// the path to invoke .../xray/index.xqy on the appserver, this should preferably be configured as a rewrite matcher
 	public String user = getPropertyWithDefault ('xray.user', null)
 	public String password = getPropertyWithDefault ('xray.password', null)
 	public boolean basicAuth = Boolean.parseBoolean (getPropertyWithDefault ('xray.basic-auth', 'false'))

--- a/xray.gradle
+++ b/xray.gradle
@@ -1,0 +1,201 @@
+
+/*
+	Gradle file to run XRay tests.  Including this in your gradle project will enable running of
+	XRay tests along with the 'test' task in your build.  If any XRay tests fail/error, then the
+	build will fail.
+
+	To use this, the XRay XQuery unit testing framework must be installed and invokable on an
+	HTTP appserver.  See the XRay project for details:
+
+		https://github.com/robwhitby/xray
+
+	In the build.gradle file, add the following line:
+
+		apply from: 'xray.gradle'
+
+	And add the http-builder dependency to the buildscript/dependencies section there (it needs
+	to be in scope before this script starts)
+
+		classpath group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
+
+	In your build.gradle file, just add this line to run XRay tests with defaults:
+
+		test.dependsOn (xray)
+
+	Note that the above requires that you apply either the Java or Groovy plugin to define the compile/test/build
+	lifecycle tasks.  If you don't want/need those, you can run the xray task directly.
+
+	This will run the XRay tests with defaults, or the property settings found in scope.  To customize
+	the XRay runner, set the following properties appropriately in gradle.properties, or $HOME/.gradle/gradle-properties,
+	or as -Pname=value parameters on the Gradle command line:
+
+		xray.scheme=http
+		xray.hostname=localhost
+		xray.port=1234
+		xray.path=/xray
+		xray.user=
+		xray.password=
+
+	These are the defaults (user and password are empty by default).  If user/password are supplied, then HTTP basic
+	credentials are applied to the request.  Digest auth is currently not possible, because the HttpBuilder class does
+	not support it.
+
+	If you want to specify settings in your build.gradle then configure the task like this (settable properties are at the
+	top of the XRayTask class below)
+
+		xray {
+			host = 'dev.mycompany.com'
+			port = 7890
+			parameters = [dir: 'mytests']
+			quiet = true
+		}
+
+	Created November 2017 by Ron Hitchens (ron@overstory.co.uk, @ronhitchens)
+ */
+
+// --------------------------------------------------------------------------
+
+buildscript {
+	repositories {
+		jcenter()
+		mavenCentral()
+	}
+	dependencies {
+		classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+	}
+}
+
+
+task xray (type: XRayTask) {
+	group = 'verification'
+	description = 'Run XRay tests on MarkLogic'
+}
+
+// -------------------------------------------------------------------------
+
+import groovyx.net.http.HTTPBuilder
+import groovyx.net.http.Method
+import groovyx.net.http.HttpResponseDecorator
+import groovy.util.slurpersupport.GPathResult
+
+class XRayTask extends DefaultTask
+{
+	public String scheme = getPropertyWithDefault ('xray.scheme', 'http')
+	public String host = getPropertyWithDefault ('xray.hostname', 'localhost')
+	public int port = Integer.parseInt (getPropertyWithDefault ('xray.port', '1234'))
+	public String path = getPropertyWithDefault ('xray.path', '/xray')	// the path to invoke xray/index.xqy on the appserver
+	public String user = getPropertyWithDefault ('xray.user', null)
+	public String password = getPropertyWithDefault ('xray.password', null)
+	public boolean quiet = Boolean.parseBoolean (getPropertyWithDefault ('xray.quiet', 'false'))	// set true to suppress passing tests
+	public Map<String,String> parameters = [:]	// XRay query params for dir, module, etc.  Not settable by properties.  Format is always forced to 'xml'.
+
+	private static final Map<String,String> colors = [failed:'\033[31m', error: '\033[1;31m', passed: '\033[32m', ignored: '\033[33m']
+
+	@TaskAction
+	void runXRay()
+	{
+		try {
+			long startTime = System.currentTimeMillis()
+			GPathResult results = invokeXrayTests()
+
+			printResults (results, quiet, colors, startTime)
+		} catch (TaskExecutionException e) {
+			throw e		// pass through, thrown from printResults if there were failures
+		} catch (Exception e) {
+			println "XRay: Unexpected exception invoking XRay tests: ${e}"
+			throw new TaskExecutionException (this, e)
+		}
+	}
+
+	private GPathResult invokeXrayTests()
+	{
+		String uriString = "${scheme}://${host}:${port}${path}"
+		HTTPBuilder builder = new HTTPBuilder (uriString)
+		String result = null
+
+		if (user != null) builder.auth.basic (user, password)
+
+		println "XRay tests starting on ${uriString}"
+
+		builder.request (Method.GET) {
+			parameters ['format'] = 'xml'
+			uri.query = parameters
+
+			response.success = { HttpResponseDecorator resp ->
+				if (resp.statusLine.statusCode == 200) {
+					result = resp.entity.content.text
+				} else {
+					String msg = "HTTP request unexpected HTTP response: ${resp.statusLine.statusCode}"
+					println msg
+					throw new RuntimeException (msg)
+				}
+
+			}
+			response.failure = { HttpResponseDecorator resp ->
+				String msg = "Unexpected error response from XRay tests: ${resp.statusLine.statusCode}"
+				println msg
+				throw new RuntimeException (msg)
+			}
+		}
+
+		new XmlSlurper().parseText (result)
+	}
+
+	private void printResults (GPathResult xml, boolean quiet, Map<String,String> colors, long startTime)
+	{
+		int pass = 0
+		int ignore = 0
+		int fail = 0
+		int error = 0
+		int total = 0
+
+		Set<String> notPass = ["failed", "error"]
+
+		xml.module.each {
+			total += Integer.parseInt (it.'@total'.text())
+			pass += Integer.parseInt (it.'@passed'.text())
+			int i = Integer.parseInt (it.'@ignored'.text())
+			ignore += i
+			int f = Integer.parseInt (it.'@failed'.text())
+			fail += f
+			int e = Integer.parseInt (it.'@error'.text())
+			error += e
+
+			boolean printModuleInfo = ( ! quiet) || ((e + f + i) != 0)
+
+			if (printModuleInfo)  {
+				println "Module: ${it.'@path'.text()}, total=${it.'@total'.text()}, pass=${it.'@passed'.text()}, fail=${it.'@failed'.text()}, error=${it.'@error'.text()}, ignore=${it.'@ignored'.text()}"
+			}
+
+			it.test.each {
+				String result = it.'@result'.text()
+				boolean printTestDetail = ( ! quiet) || ( ! "passed".equals (result))
+
+				if (printTestDetail) println " ${colors[result]}${result.toUpperCase()}\033[0m: ${it.'@name'.text()} (${it.'@time'.text()})"
+
+				if (notPass.contains (result)) {
+					println "     assert: ${it.assert.'@test'.text()}"
+					println "     actual: ${it.assert.actual.text()}"
+					println "   expected: ${it.assert.expected.text()}"
+					println "    message: ${it.assert.message.text()}"
+				}
+			}
+		}
+
+		double seconds = (double)(System.currentTimeMillis() - startTime) / 1000.0
+		int notPassed = error + fail
+		String color = (notPassed != 0) ? colors ['failed'] : (ignore != 0) ? colors ['ignored'] : colors ['passed']
+
+		println "XRay results: ${color}total=${total}, pass=${pass}, fail=${fail}, error=${error}, ignore=${ignore}\033[0m, elapsed ${seconds} seconds"
+
+		if (notPassed > 0) {
+			throw new TaskExecutionException (this, new RuntimeException ("There were ${notPassed} XRay test failures"))
+		}
+	}
+
+	private String getPropertyWithDefault (String propName, String defaultValue)
+	{
+		(project.hasProperty (propName)) ? project.properties[propName] : defaultValue
+	}
+}
+


### PR DESCRIPTION
Rob,
Here's a an update for XRay that adds a file `xray.gradle` that you can include from your project's Gradle `build.gradle` file to run XRay tests from the build (and fail the build if any tests fail).  I also added a skeleton `build.gradle` file to show how to use it, and tweaked the `README.md` file as well.

I left these files at the top level rather than putting them in a subdir.  I figure that with them there, you could more easily include it directly from the source if that's convenient.

If you're happy with this, go ahead and merge it into your repo.  Or if you want me to make some changes, let me know.

Cheers.